### PR TITLE
Add Sandalwood Vanilla SVA variation

### DIFF
--- a/pypura/fragrances.json
+++ b/pypura/fragrances.json
@@ -2916,6 +2916,12 @@
     "brand": "Anthropologie"
   },
   {
+    "name": "Sandalwood Vanilla",
+    "type": "Fragrance",
+    "sku": "SVA",
+    "brand": "Anthropologie"
+  },
+  {
     "name": "Santa Fe",
     "type": "Fragrance",
     "sku": "SNF",


### PR DESCRIPTION
Just received and set up the Pura 3, 4 and Car. While doing so, I came across the Sandalwood Vanilla fragrance returning an unknown code. By the looks of it, you already have the exact fragrance defined, but with a SKU of `SVAH` (mine has a code of `SVA`). Although they are the same brand, perhaps this is a difference in the "smart" fragrance now having a SKU of `SVA`. Regardless, I just added this as an extra option as I'm sure individuals will come across both the `SVA` and `SVAH` variants down the road.

Debug of the bay from Home Assistant:

```
'bay1': {'msg': '', 'wearingTime': 1735, 'code': 'SVA', 'min': 64, 'max': 85, 'vialId': 'e66a6e37-7259-4c7f-94b8-17455703e008', 'id': 1694623148, 'activeAt': 0, 'isSmartVial': False}
```

Although I can confirm this vial is a smart vial (has the chip on the bottom), the `isSmartVial` key is returning False - seems odd that they aren't setting it as a smart vial even though the different SKU and needing to scan the QR code would let them know it is in fact one of their smart vials. Looks like, instead, they mark smart vials as False if they are installed in a Pura 3.